### PR TITLE
test two dyndb instances in one named process

### DIFF
--- a/bin/tests/system/dyndb/ns1/named.conf
+++ b/bin/tests/system/dyndb/ns1/named.conf
@@ -39,3 +39,4 @@ controls {
 };
 
 dyndb sample "../driver/sample.so" { ipv4.example.nil. in-addr.arpa. };
+dyndb sample2 "../driver/sample.so" { ipv6.example.nil. 8.b.d.0.1.0.0.2.ip6.arpa. };

--- a/bin/tests/system/dyndb/ns1/named.conf
+++ b/bin/tests/system/dyndb/ns1/named.conf
@@ -38,4 +38,4 @@ controls {
 	inet 10.53.0.1 port 9953 allow { any; } keys { rndc_key; };
 };
 
-dyndb sample "../driver/sample.so" { example.nil. arpa. };
+dyndb sample "../driver/sample.so" { ipv4.example.nil. in-addr.arpa. };

--- a/bin/tests/system/dyndb/tests.sh
+++ b/bin/tests/system/dyndb/tests.sh
@@ -106,22 +106,22 @@ EOF
     return 0
 }
 
-test_add test1.example.nil. A "10.53.0.10" || ret=1
+test_add test1.ipv4.example.nil. A "10.53.0.10" || ret=1
 status=`expr $status + $ret`
 
-test_add test2.example.nil. A "10.53.0.11" || ret=1
+test_add test2.ipv4.example.nil. A "10.53.0.11" || ret=1
 status=`expr $status + $ret`
 
-test_add test3.example.nil. A "10.53.0.12" || ret=1
+test_add test3.ipv4.example.nil. A "10.53.0.12" || ret=1
 status=`expr $status + $ret`
 
-test_del test3.example.nil. A || ret=1
+test_del test3.ipv4.example.nil. A || ret=1
 status=`expr $status + $ret`
 
-test_del test2.example.nil. A || ret=1
+test_del test2.ipv4.example.nil. A || ret=1
 status=`expr $status + $ret`
 
-test_del test1.example.nil. A || ret=1
+test_del test1.ipv4.example.nil. A || ret=1
 status=`expr $status + $ret`
 
 exit $status

--- a/bin/tests/system/dyndb/tests.sh
+++ b/bin/tests/system/dyndb/tests.sh
@@ -115,6 +115,9 @@ status=`expr $status + $ret`
 test_add test3.ipv4.example.nil. A "10.53.0.12" || ret=1
 status=`expr $status + $ret`
 
+test_add test4.ipv6.example.nil. AAAA "2001:db8::1" || ret=1
+status=`expr $status + $ret`
+
 test_del test3.ipv4.example.nil. A || ret=1
 status=`expr $status + $ret`
 
@@ -122,6 +125,9 @@ test_del test2.ipv4.example.nil. A || ret=1
 status=`expr $status + $ret`
 
 test_del test1.ipv4.example.nil. A || ret=1
+status=`expr $status + $ret`
+
+test_del test4.ipv6.example.nil. AAAA || ret=1
 status=`expr $status + $ret`
 
 exit $status

--- a/bin/tests/system/dyndb/tests.sh
+++ b/bin/tests/system/dyndb/tests.sh
@@ -72,7 +72,7 @@ test_del() {
     host="$1"
     type="$2"
 
-    ip=`$DIG $DIGOPTS +short $host`
+    ip=`$DIG $DIGOPTS +short $host $type`
 
     cat <<EOF > ns1/update.txt
 server 10.53.0.1 5300


### PR DESCRIPTION
This is legitimate scenario because you might want to use one dyndb driver in two distinct views or so. Currently it crashes because of conflicts on the global isc_hashctx.
